### PR TITLE
feat: add Zeabur one-click deploy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Go Version](https://img.shields.io/badge/Go-1.24+-blue.svg)](https://golang.org)
 [![License: PolyForm Noncommercial](https://img.shields.io/badge/License-PolyForm%20Noncommercial-orange.svg)](https://polyformproject.org/licenses/noncommercial/1.0.0/)
-[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/FOFRHZ)
 
 ## ✨ 特性
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Go Version](https://img.shields.io/badge/Go-1.24+-blue.svg)](https://golang.org)
 [![License: PolyForm Noncommercial](https://img.shields.io/badge/License-PolyForm%20Noncommercial-orange.svg)](https://polyformproject.org/licenses/noncommercial/1.0.0/)
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
 
 ## ✨ 特性
 
@@ -84,6 +85,21 @@ go run main.go
 服务将在 `http://localhost:8002` 启动
 
 ## 🚀 服务器部署方式
+
+### Zeabur 一键部署（推荐）
+
+点击下方按钮即可一键部署到 Zeabur：
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
+
+或者使用 Zeabur CLI 部署：
+```bash
+npx zeabur@latest template deploy -f zeabur-template.yaml
+```
+
+详细部署指南请参考 [Zeabur 部署文档](docs/zeabur-deploy.md)。
+
+---
 
 ### Docker 部署
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,6 +6,7 @@ A Go service that converts Cursor Web into an OpenAI `chat/completions` compatib
 
 [![Go Version](https://img.shields.io/badge/Go-1.24+-blue.svg)](https://golang.org)
 [![License: PolyForm Noncommercial](https://img.shields.io/badge/License-PolyForm%20Noncommercial-orange.svg)](https://polyformproject.org/licenses/noncommercial/1.0.0/)
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
 
 ## ✨ Features
 
@@ -87,6 +88,21 @@ go run main.go
 The service will start at `http://localhost:8002`
 
 ## 🚀 Server Deployment Methods
+
+### Zeabur One-Click Deploy (Recommended)
+
+Click the button below to deploy to Zeabur with one click:
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
+
+Or use the Zeabur CLI:
+```bash
+npx zeabur@latest template deploy -f zeabur-template.yaml
+```
+
+For detailed deployment guide, see [Zeabur Deployment Guide](docs/zeabur-deploy.md).
+
+---
 
 ### Docker Deployment
 

--- a/docs/zeabur-deploy.md
+++ b/docs/zeabur-deploy.md
@@ -1,0 +1,223 @@
+# Zeabur 一键部署指南
+
+[English](#english) | 简体中文
+
+本文档将指导你如何将 Cursor2API-Go 一键部署到 [Zeabur](https://zeabur.com) 平台。
+
+## 📋 前提条件
+
+1. 一个 [Zeabur 账号](https://zeabur.com)（免费注册即可）
+2. Zeabur 付费计划（Dev 或 Team Plan，用于运行持久服务）
+
+## 🚀 方法一：一键部署按钮（最简单）
+
+直接点击下方按钮，即可跳转到 Zeabur 完成一键部署：
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
+
+### 部署步骤
+
+1. **点击部署按钮** — 跳转到 Zeabur 模板部署页面
+2. **填写配置参数**：
+   - **Domain（域名）**：选择或输入你想绑定的域名（可使用 Zeabur 免费提供的 `*.zeabur.app` 域名）
+   - **API Key**：设置 API 认证密钥（默认为 `0000`，**生产环境请务必修改**）
+   - **Models**：基础模型列表，逗号分隔（默认为 `claude-sonnet-4.6`）
+3. **选择区域** — 选择部署区域（建议选择离你最近的区域）
+4. **确认部署** — 点击部署按钮，等待构建完成
+
+部署通常在 2-5 分钟内完成。
+
+## 🛠️ 方法二：使用 Zeabur CLI 部署
+
+如果你偏好命令行操作：
+
+### 1. 安装 Zeabur CLI
+
+```bash
+npm install -g zeabur
+```
+
+### 2. 登录
+
+```bash
+zeabur auth login
+```
+
+### 3. 使用模板部署
+
+```bash
+# 克隆项目
+git clone https://github.com/jacob-sheng/cursor2api-go.git
+cd cursor2api-go
+
+# 使用模板文件部署
+npx zeabur@latest template deploy -f zeabur-template.yaml
+```
+
+### 4. 使用 API 密钥部署（高级）
+
+如果你有 Zeabur API 密钥，可以直接使用 API 进行部署：
+
+```bash
+# 设置 API 密钥
+export ZEABUR_TOKEN=sk-your-api-key
+
+# 部署模板
+npx zeabur@latest template deploy -f zeabur-template.yaml
+```
+
+## 🔧 方法三：手动在 Zeabur Dashboard 部署
+
+1. 登录 [Zeabur Dashboard](https://dash.zeabur.com)
+2. 点击 **Create Project** 创建新项目
+3. 选择部署区域
+4. 点击 **Add Service** → **Git** → 连接你的 GitHub 账号
+5. 选择 `cursor2api-go` 仓库
+6. Zeabur 会自动检测 Dockerfile 并开始构建
+7. 构建完成后，在服务设置中：
+   - 添加自定义域名或使用 `*.zeabur.app` 域名
+   - 设置环境变量
+
+## ⚙️ 部署后配置
+
+### 环境变量设置
+
+部署完成后，在 Zeabur Dashboard 的服务设置中配置以下环境变量：
+
+| 变量名 | 默认值 | 说明 |
+|--------|--------|------|
+| `PORT` | `8002` | 服务器端口（Zeabur 会自动处理端口映射） |
+| `API_KEY` | `0000` | **⚠️ 务必修改！** API 认证密钥 |
+| `MODELS` | `claude-sonnet-4.6` | 基础模型列表，逗号分隔 |
+| `DEBUG` | `false` | 调试模式（生产环境建议关闭） |
+| `TIMEOUT` | `60` | 请求超时时间（秒） |
+| `KILO_TOOL_STRICT` | `false` | Kilo Code 兼容模式 |
+
+### 域名绑定
+
+1. 在 Zeabur Dashboard 中，进入你的服务
+2. 点击 **Networking** 选项卡
+3. 点击 **Generate Domain** 获取一个免费的 `*.zeabur.app` 域名
+4. 或者点击 **Custom Domain** 绑定你自己的域名
+   - 需要在你的 DNS 服务商处添加 CNAME 记录指向 Zeabur 提供的地址
+
+### 验证部署
+
+部署完成后，通过以下方式验证服务是否正常运行：
+
+```bash
+# 健康检查
+curl https://your-domain.zeabur.app/health
+
+# 获取模型列表
+curl -H "Authorization: Bearer your-api-key" https://your-domain.zeabur.app/v1/models
+
+# 测试聊天
+curl -X POST https://your-domain.zeabur.app/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-api-key" \
+  -d '{
+    "model": "claude-sonnet-4.6",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": false
+  }'
+```
+
+## 📊 监控与日志
+
+在 Zeabur Dashboard 中可以方便地查看：
+
+- **日志**：实时查看服务日志输出
+- **指标**：监控 CPU、内存使用情况
+- **部署历史**：查看所有部署记录和回滚
+
+## 🔄 更新部署
+
+当 GitHub 仓库有新的 commit 推送时，Zeabur 会自动重新部署最新版本。
+
+你也可以手动触发重新部署：
+1. 进入 Zeabur Dashboard
+2. 选择你的服务
+3. 点击 **Redeploy**
+
+## ❓ 常见问题
+
+### Q: 部署失败怎么办？
+A: 查看 Zeabur Dashboard 中的构建日志，常见原因包括：
+- 内存不足：尝试升级到更高规格
+- 构建超时：检查网络连接
+
+### Q: 服务启动后无法访问？
+A: 确认以下几点：
+1. 是否已绑定域名
+2. 端口配置是否正确（默认 8002）
+3. 检查健康检查 `/health` 端点是否正常响应
+
+### Q: 如何使用自定义域名？
+A: 在 Zeabur Dashboard 的 Networking 设置中添加自定义域名，并在 DNS 添加 CNAME 记录。
+
+---
+
+<a id="english"></a>
+
+# Zeabur One-Click Deployment Guide
+
+English | [简体中文](#zeabur-一键部署指南)
+
+This guide walks you through deploying Cursor2API-Go to [Zeabur](https://zeabur.com) with one click.
+
+## 📋 Prerequisites
+
+1. A [Zeabur account](https://zeabur.com) (free signup)
+2. A Zeabur paid plan (Dev or Team Plan for persistent services)
+
+## 🚀 Method 1: One-Click Deploy Button (Easiest)
+
+Click the button below to deploy directly on Zeabur:
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/cursor2api-go)
+
+### Steps
+
+1. **Click the deploy button** — Redirects to the Zeabur template deployment page
+2. **Fill in configuration**:
+   - **Domain**: Choose or enter a domain (you can use Zeabur's free `*.zeabur.app` domain)
+   - **API Key**: Set the API authentication key (default is `0000`, **change for production!**)
+   - **Models**: Comma-separated base model list (default: `claude-sonnet-4.6`)
+3. **Select region** — Choose a deployment region close to you
+4. **Confirm deployment** — Click deploy and wait for the build to finish
+
+Deployment usually completes in 2-5 minutes.
+
+## 🛠️ Method 2: Deploy with Zeabur CLI
+
+```bash
+# Clone the project
+git clone https://github.com/jacob-sheng/cursor2api-go.git
+cd cursor2api-go
+
+# Deploy using the template file
+npx zeabur@latest template deploy -f zeabur-template.yaml
+```
+
+## ⚙️ Post-Deployment Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8002` | Server port (Zeabur handles port mapping) |
+| `API_KEY` | `0000` | **⚠️ Change this!** API authentication key |
+| `MODELS` | `claude-sonnet-4.6` | Base model list, comma-separated |
+| `DEBUG` | `false` | Debug mode (disable in production) |
+| `TIMEOUT` | `60` | Request timeout (seconds) |
+
+### Verify Deployment
+
+```bash
+# Health check
+curl https://your-domain.zeabur.app/health
+
+# List models
+curl -H "Authorization: Bearer your-api-key" https://your-domain.zeabur.app/v1/models
+```

--- a/zeabur-template.yaml
+++ b/zeabur-template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: Cursor2API-Go
 spec:
   description: A Go service that converts Cursor Web into OpenAI chat/completions compatible API
-  icon: https://raw.githubusercontent.com/jacob-sheng/cursor2api-go/main/docs/images/home.png
+  icon: https://raw.githubusercontent.com/libaxuan/cursor2api-go/main/docs/images/home.png
   tags:
     - Tool
     - AI
@@ -41,16 +41,14 @@ spec:
     - `MODELS`: Base model list, comma-separated (default: claude-sonnet-4.6)
     - `DEBUG`: Enable debug mode (default: false)
     - `TIMEOUT`: Request timeout in seconds (default: 60)
-
   services:
     - name: cursor2api-go
       template: GIT
       domainKey: PUBLIC_DOMAIN
       spec:
         source:
-          type: GITHUB
-          repoID: 1066838979
-          repo: libaxuan/cursor2api-go
+          source: GITHUB
+          repo: 1066838979
           branch: main
         ports:
           - id: web
@@ -67,23 +65,9 @@ spec:
             default: "false"
           TIMEOUT:
             default: "60"
-
   localization:
     zh-CN:
       description: 一个将 Cursor Web 转换为 OpenAI chat/completions 兼容 API 的 Go 服务
-      variables:
-        - key: PUBLIC_DOMAIN
-          type: DOMAIN
-          name: 域名
-          description: 你想为 Cursor2API 服务绑定哪个域名？
-        - key: API_KEY
-          type: STRING
-          name: API 密钥
-          description: 服务的 API 认证密钥（默认为 0000）
-        - key: MODELS
-          type: STRING
-          name: 模型列表
-          description: "基础模型列表，逗号分隔（默认：claude-sonnet-4.6）"
       readme: |-
         # Cursor2API-Go
 

--- a/zeabur-template.yaml
+++ b/zeabur-template.yaml
@@ -1,0 +1,106 @@
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: Cursor2API-Go
+spec:
+  description: A Go service that converts Cursor Web into OpenAI chat/completions compatible API
+  icon: https://raw.githubusercontent.com/jacob-sheng/cursor2api-go/main/docs/images/home.png
+  tags:
+    - Tool
+    - AI
+  variables:
+    - key: PUBLIC_DOMAIN
+      type: DOMAIN
+      name: Domain
+      description: What domain do you want for your Cursor2API service?
+    - key: API_KEY
+      type: STRING
+      name: API Key
+      description: API authentication key for the service (default is 0000)
+    - key: MODELS
+      type: STRING
+      name: Models
+      description: "Comma-separated base model list (default: claude-sonnet-4.6)"
+  readme: |-
+    # Cursor2API-Go
+
+    A Go service that converts Cursor Web into an OpenAI `chat/completions` compatible API.
+
+    ## Features
+    - 🔄 **API Compatible**: OpenAI `chat/completions` interface compatible
+    - ⚡ **High Performance**: Low latency response
+    - 🔐 **Secure Auth**: API Key authentication support
+    - 🌐 **Model Derivation**: Automatically exposes `*-thinking` models
+    - 🧰 **Tool Calls**: Supports `tools` / `tool_choice` / `tool_calls`
+    - 🛡️ **Error Handling**: Comprehensive error handling
+    - 📊 **Health Check**: Built-in health check endpoint
+
+    ## Configuration
+    Set environment variables after deployment:
+    - `API_KEY`: API authentication key (default: 0000)
+    - `MODELS`: Base model list, comma-separated (default: claude-sonnet-4.6)
+    - `DEBUG`: Enable debug mode (default: false)
+    - `TIMEOUT`: Request timeout in seconds (default: 60)
+
+  services:
+    - name: cursor2api-go
+      template: GIT
+      domainKey: PUBLIC_DOMAIN
+      spec:
+        source:
+          type: GITHUB
+          repoID: 1066838979
+          repo: libaxuan/cursor2api-go
+          branch: main
+        ports:
+          - id: web
+            port: 8002
+            type: HTTP
+        env:
+          PORT:
+            default: "8002"
+          API_KEY:
+            default: ${API_KEY}
+          MODELS:
+            default: ${MODELS}
+          DEBUG:
+            default: "false"
+          TIMEOUT:
+            default: "60"
+
+  localization:
+    zh-CN:
+      description: 一个将 Cursor Web 转换为 OpenAI chat/completions 兼容 API 的 Go 服务
+      variables:
+        - key: PUBLIC_DOMAIN
+          type: DOMAIN
+          name: 域名
+          description: 你想为 Cursor2API 服务绑定哪个域名？
+        - key: API_KEY
+          type: STRING
+          name: API 密钥
+          description: 服务的 API 认证密钥（默认为 0000）
+        - key: MODELS
+          type: STRING
+          name: 模型列表
+          description: "基础模型列表，逗号分隔（默认：claude-sonnet-4.6）"
+      readme: |-
+        # Cursor2API-Go
+
+        一个将 Cursor Web 转换为 OpenAI `chat/completions` 兼容 API 的 Go 服务。
+
+        ## 特性
+        - 🔄 **API 兼容**: 兼容 OpenAI `chat/completions` 接口
+        - ⚡ **高性能**: 低延迟响应
+        - 🔐 **安全认证**: 支持 API Key 认证
+        - 🌐 **模型派生**: 自动暴露 `*-thinking` 模型
+        - 🧰 **工具调用**: 支持 `tools` / `tool_choice` / `tool_calls`
+        - 🛡️ **错误处理**: 完善的错误处理机制
+        - 📊 **健康检查**: 内置健康检查接口
+
+        ## 配置说明
+        部署后可设置以下环境变量：
+        - `API_KEY`: API 认证密钥（默认: 0000）
+        - `MODELS`: 基础模型列表，逗号分隔（默认: claude-sonnet-4.6）
+        - `DEBUG`: 启用调试模式（默认: false）
+        - `TIMEOUT`: 请求超时时间，单位秒（默认: 60）


### PR DESCRIPTION
## 变更内容

添加 Zeabur 一键部署功能，让用户可以快速将 Cursor2API-Go 部署到 Zeabur 平台。

### 新增文件

- **`zeabur-template.yaml`** — Zeabur 模板配置文件
- **`docs/zeabur-deploy.md`** — 详细的 Zeabur 部署指南（中英双语）

### 修改文件

- **`README.md`** — 添加 Zeabur 部署按钮和部署入口
- **`README_EN.md`** — 添加英文版 Zeabur 部署按钮和部署入口

### 使用方式

1. 点击 README 中的 Deploy on Zeabur 按钮
2. 使用 CLI: `npx zeabur@latest template deploy -f zeabur-template.yaml`
